### PR TITLE
feat(embedding): integrar servicio de generación de embeddings con Ollama

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.ai:spring-ai-starter-model-ollama'
-	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+	//implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,15 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  ollama:
+    image: ollama/ollama
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    pull_policy: always
+
 volumes:
   pgdata:
+  ollama:

--- a/src/main/java/com/kalapa/heuristik/application/service/VentasPorPeriodoService.java
+++ b/src/main/java/com/kalapa/heuristik/application/service/VentasPorPeriodoService.java
@@ -1,0 +1,74 @@
+package com.kalapa.heuristik.application.service;
+
+import com.kalapa.heuristik.domain.repository.VentaRepository;
+import com.kalapa.heuristik.domain.service.EmbeddingGenerator;
+import com.kalapa.heuristik.interfaces.dto.ResumenVentasEmbeddingDto;
+import com.kalapa.heuristik.interfaces.dto.VentasPorDiaDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VentasPorPeriodoService {
+
+    private final VentaRepository ventaRepository;
+    private final EmbeddingGenerator embeddingGenerator;
+
+    public ResumenVentasEmbeddingDto generarEmbedding(String mes) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-yyyy");
+        YearMonth yearMonth = YearMonth.parse(mes, formatter);
+
+        ZoneId zona = ZoneId.systemDefault(); // o ZoneOffset.UTC si prefieres
+
+        Instant inicio = yearMonth.atDay(1).atStartOfDay(zona).toInstant();
+        Instant fin = yearMonth.atEndOfMonth().atTime(LocalTime.MAX).atZone(zona).toInstant();
+
+        List<VentasPorDiaDto> ventasPorDia = ventaRepository.findVentasAgrupadasPorDia(inicio, fin);
+
+        if (ventasPorDia.isEmpty()) {
+            return new ResumenVentasEmbeddingDto(
+                    "No hay datos de ventas para el mes " + mes,
+                    new float[0]
+            );
+        }
+
+        VentasPorDiaDto mejorDia = ventasPorDia.get(0);
+        VentasPorDiaDto peorDia = ventasPorDia.get(ventasPorDia.size() - 1);
+
+        StringBuilder resumen = new StringBuilder();
+        resumen.append("Durante el mes ").append(mes).append(": ");
+        resumen.append("El día con más ventas fue ")
+                .append(mejorDia.dia()).append(" (")
+                .append(diaEnEspañol(mejorDia.dia().toLocalDate().getDayOfWeek())).append(") con ")
+                .append(mejorDia.totalVentas()).append(" transacciones. ");
+        resumen.append("El día con menos ventas fue ")
+                .append(peorDia.dia()).append(" (")
+                .append(diaEnEspañol(peorDia.dia().toLocalDate().getDayOfWeek())).append(") con ")
+                .append(peorDia.totalVentas()).append(" transacciones. ");
+        resumen.append("Esto podría indicar que los ")
+                .append(diaEnEspañol(mejorDia.dia().toLocalDate().getDayOfWeek()))
+                .append("s son fuertes comercialmente, mientras que los ")
+                .append(diaEnEspañol(peorDia.dia().toLocalDate().getDayOfWeek()))
+                .append("s podrían requerir incentivos o promociones.");
+
+        float[] embedding = embeddingGenerator.generateVector(resumen.toString());
+
+        return new ResumenVentasEmbeddingDto(resumen.toString(), embedding);
+    }
+
+    private String diaEnEspañol(DayOfWeek dia) {
+        return switch (dia) {
+            case MONDAY -> "lunes";
+            case TUESDAY -> "martes";
+            case WEDNESDAY -> "miércoles";
+            case THURSDAY -> "jueves";
+            case FRIDAY -> "viernes";
+            case SATURDAY -> "sábado";
+            case SUNDAY -> "domingo";
+        };
+    }
+}

--- a/src/main/java/com/kalapa/heuristik/domain/repository/VentaRepository.java
+++ b/src/main/java/com/kalapa/heuristik/domain/repository/VentaRepository.java
@@ -1,0 +1,24 @@
+package com.kalapa.heuristik.domain.repository;
+
+import com.kalapa.heuristik.domain.entities.Venta;
+import com.kalapa.heuristik.interfaces.dto.VentasPorDiaDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface VentaRepository extends JpaRepository<Venta, Long> {
+
+    @Query(value = """
+         SELECT
+                    CAST(v.fecha AS date), 
+                    COUNT(v)
+                FROM Venta v
+                WHERE v.fecha BETWEEN :inicio AND :fin
+                GROUP BY CAST(v.fecha AS date)
+                ORDER BY COUNT(v) DESC;
+        """, nativeQuery = true)
+    List<VentasPorDiaDto> findVentasAgrupadasPorDia(Instant inicio, Instant fin);
+}

--- a/src/main/java/com/kalapa/heuristik/domain/service/EmbeddingGenerator.java
+++ b/src/main/java/com/kalapa/heuristik/domain/service/EmbeddingGenerator.java
@@ -1,0 +1,7 @@
+package com.kalapa.heuristik.domain.service;
+
+import java.util.List;
+
+public interface EmbeddingGenerator {
+    float[] generateVector(String texto);
+}

--- a/src/main/java/com/kalapa/heuristik/infrastructure/client/OllamaEmbeddingService.java
+++ b/src/main/java/com/kalapa/heuristik/infrastructure/client/OllamaEmbeddingService.java
@@ -1,0 +1,23 @@
+package com.kalapa.heuristik.infrastructure.client;
+
+import com.kalapa.heuristik.domain.service.EmbeddingGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OllamaEmbeddingService implements EmbeddingGenerator {
+
+    private final EmbeddingModel embeddingModel;
+
+    @Override
+    public float[] generateVector(String texto) {
+        EmbeddingResponse response = embeddingModel.embedForResponse(List.of(texto));
+        return response.getResults().get(0).getOutput();
+    }
+}

--- a/src/main/java/com/kalapa/heuristik/interfaces/controller/EmbeddingTestController.java
+++ b/src/main/java/com/kalapa/heuristik/interfaces/controller/EmbeddingTestController.java
@@ -1,0 +1,22 @@
+package com.kalapa.heuristik.interfaces.controller;
+
+import com.kalapa.heuristik.application.service.VentasPorPeriodoService;
+import com.kalapa.heuristik.interfaces.dto.ResumenVentasEmbeddingDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ai/embedding")
+@RequiredArgsConstructor
+public class EmbeddingTestController {
+
+    private final VentasPorPeriodoService ventasPorPeriodoService;
+
+    @GetMapping("/resumen-mes/{mes}")
+    public ResumenVentasEmbeddingDto generarEmbeddingResumenMes(@PathVariable String mes) {
+        return ventasPorPeriodoService.generarEmbedding(mes);
+    }
+}

--- a/src/main/java/com/kalapa/heuristik/interfaces/dto/ResumenVentasEmbeddingDto.java
+++ b/src/main/java/com/kalapa/heuristik/interfaces/dto/ResumenVentasEmbeddingDto.java
@@ -1,0 +1,7 @@
+package com.kalapa.heuristik.interfaces.dto;
+
+public record ResumenVentasEmbeddingDto(
+        String resumen,
+        float[] embedding
+) {
+}

--- a/src/main/java/com/kalapa/heuristik/interfaces/dto/VentasPorDiaDto.java
+++ b/src/main/java/com/kalapa/heuristik/interfaces/dto/VentasPorDiaDto.java
@@ -1,0 +1,9 @@
+package com.kalapa.heuristik.interfaces.dto;
+
+import java.sql.Date;
+
+public record VentasPorDiaDto(
+        Date dia,
+        Long totalVentas
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,9 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
+  ai:
+    ollama:
+      embedding:
+        enabled: true
+        model: paraphrase-multilingual
+        base-url: http://localhost:11434


### PR DESCRIPTION
- Se generó el servicio EmbeddingGenerator para generar vectores usando el endpoint /api/embed de Ollama.
- Se generó el servicio VentasPorPeriodoService para generar resumen de ventas mensual y su embedding.
- Se generó la consulta para en ventas
- Se validó la respuesta y formato de los vectores generados.